### PR TITLE
Fixed build error by reverting the updating of '@angular-devkit/build…

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "zone.js": "~0.11.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~17.1.1",
+    "@angular-devkit/build-angular": "0.1102.3",
     "@angular/cli": "~11.2.4",
     "@angular/compiler-cli": "~11.2.5",
     "@types/jasmine": "~3.6.0",


### PR DESCRIPTION
## Problem
- `ng build` fails because the package `@angular-devkit/build-angular` version 17 contains language features incompatible with this project.

![Screenshot from 2024-03-23 11-25-56](https://github.com/techsoft3d/hwp-demo-angular/assets/61014463/23c252dd-50a8-440e-848f-26f6db9a6b6e)

The nullish coalescing operator wasn't introduced until ES2020.

## Solution
- Revert the version of `@angular-devkitbuild-angular` to version `0.1102.3`

![Screenshot from 2024-03-23 11-30-46](https://github.com/techsoft3d/hwp-demo-angular/assets/61014463/d86f46d3-4f41-4303-8c11-deb3380b14fc)

## Notes
Used Node version `14.21.3`